### PR TITLE
Fix i386 detection

### DIFF
--- a/pt.py
+++ b/pt.py
@@ -168,7 +168,7 @@ class PageTableDump(gdb.Command):
             self.backend = PT_Aarch64_Backend(self.phys_mem)
         elif "x86-64" in arch or "x64-64" in arch:
             self.backend = PT_x86_64_Backend(self.phys_mem)
-        elif "x86-32" in arch or "x64-32" in arch or "(currently i386)" in arch:
+        elif "x86-32" in arch or "x64-32" in arch or "i386" in arch:
             self.backend = PT_x86_32_Backend(self.phys_mem)
         elif "riscv:rv64" in arch:
             self.backend = PT_RiscV64_Backend(self.phys_mem)


### PR DESCRIPTION
On newer versions of GDB (tested on GDB 13, but probably was changed in an earlier version), the `(currently i386)` string was changed to `(currently "i386")`, which results in the i386 detection in gdb-pt-dump failing. Relaxing the search string to just "i386" fixes this issue.