### PR TITLE
VMPhysMem

### DIFF
--- a/pt.py
+++ b/pt.py
@@ -62,7 +62,7 @@ class VMPhysMem():
         self.file = os.open(f"/proc/{pid}/mem", os.O_RDONLY)
         self.mem_size = os.fstat(self.file).st_size
 
-    def __close__(self):
+    def __del__(self):
         if self.file:
             os.close(self.file)
 


### PR DESCRIPTION
In pt.py , the destructor of VMPhysMem is not correct. The destructor should be __del__ in python.

```
class VMPhysMem():
    def __init__(self, pid):
        self.pid = pid
        self.file = os.open(f"/proc/{pid}/mem", os.O_RDONLY)
        self.mem_size = os.fstat(self.file).st_size

    def __close__(self):
        if self.file:
            os.close(self.file)
```

This would cause gdb to open too many files and not have a chance to close them.

![image](https://github.com/martinradev/gdb-pt-dump/assets/83495929/a33cac4b-673d-4fae-9f27-09661769809c)

When i execute ni ,si,.. and so on,gdb will reopen /proc/pid/mem. But the previsous opened file will not be closed.
When I type these commands multiple times, more and more files will be opened.

![image](https://github.com/martinradev/gdb-pt-dump/assets/83495929/ea64407f-6b4f-453e-aa79-3ea2f4a1909f)

When the number of open files reaches the maximum, it causes a program exception.

![image](https://github.com/martinradev/gdb-pt-dump/assets/83495929/9d91d5f4-48ff-4c64-a28e-b04491469341)


After adjusting the original code, It can work well.
```
class VMPhysMem():
    def __init__(self, pid):
        self.pid = pid
        self.file = os.open(f"/proc/{pid}/mem", os.O_RDONLY)
        self.mem_size = os.fstat(self.file).st_size

    def __del__(self):
        if self.file:
            os.close(self.file)
```

![image](https://github.com/martinradev/gdb-pt-dump/assets/83495929/0a1a55fb-6991-4628-b27f-acd8446512ec)
