### PR TITLE
[WIP] pt: add option to dump host page tables

### DIFF
--- a/pt.py
+++ b/pt.py
@@ -5,6 +5,6 @@ import os
 dirname = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(1, dirname)
 
-from pt import PageTableDump
+from pt_gdb import PageTableDumpGdbFrontend
 
-PageTableDump()
+PageTableDumpGdbFrontend()

--- a/pt/__init__.py
+++ b/pt/__init__.py
@@ -1,1 +1,0 @@
-from pt.pt import PageTableDump

--- a/pt/machine.py
+++ b/pt/machine.py
@@ -1,0 +1,22 @@
+from abc import ABC
+from abc import abstractmethod
+import os
+import subprocess
+
+class Machine(ABC):
+
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def read_register(self, register_name):
+        raise Exception("Unimplemented")
+
+    @abstractmethod
+    def read_physical_memory(self, physical_address, length):
+        raise Exception("Unimplemented")
+
+    @abstractmethod
+    def read_virtual_memory(self, virtual_address, length):
+        raise Exception("Unimplemented")
+

--- a/pt/pt.py
+++ b/pt/pt.py
@@ -1,4 +1,3 @@
-import gdb
 import sys
 import argparse
 import os
@@ -9,211 +8,12 @@ import random
 import traceback
 
 from pt.pt_common import *
-from pt.pt_x86_64_parse import *
-from pt.pt_aarch64_parse import *
-from pt.pt_riscv64_parse import *
 
-def _search_pids_for_file(pids, filename):
-    for pid in pids:
-        fd_dir = f"/proc/{pid}/fd"
+class PageTableDump():
 
-        try:
-            for fd in os.listdir(fd_dir):
-                if os.readlink(f"{fd_dir}/{fd}") == filename:
-                    return pid
-        except FileNotFoundError:
-            # Either the process has gone or fds are changing, not our pid
-            pass
-        except PermissionError:
-            # Evade processes owned by other users
-            pass
-
-    return None
-
-def get_qemu_pid():
-    out = subprocess.check_output(["pgrep", "qemu-system"], encoding="utf8")
-    pids = out.strip().split('\n')
-
-    if len(pids) == 1:
-        return int(pids[0], 10)
-
-    # We add a chardev file backend (we dont add a fronted, so it doesn't affect
-    # the guest). We can then look through proc to find which process has the file
-    # open. This approach is agnostic to namespaces (pid, network and mount).
-    chardev_id = "gdb-pt-dump" + '-' + ''.join(random.choices(string.ascii_letters, k=16))
-    with tempfile.NamedTemporaryFile() as t:
-        gdb.execute(f"monitor chardev-add file,id={chardev_id},path={t.name}")
-        ret = _search_pids_for_file(pids, t.name)
-        gdb.execute(f"monitor chardev-remove {chardev_id}")
-
-    if not ret:
-        raise Exception("Could not find qemu pid")
-
-    return int(ret, 10)
-
-
-class VMPhysMem():
-    def __init__(self, pid):
-        self.pid = pid
-        self.file = os.open(f"/proc/{pid}/mem", os.O_RDONLY)
-        self.mem_size = os.fstat(self.file).st_size
-
-    def __close__(self):
-        if self.file:
-            os.close(self.file)
-
-    def read(self, phys_addr, len):
-        res = gdb.execute(f"monitor gpa2hva {hex(phys_addr)}", to_string = True)
-
-        # It's not possible to pread large sizes, so let's break the request
-        # into a few smaller ones.
-        max_block_size = 1024 * 1024 * 256
-        try:
-            hva = int(res.split(" ")[-1], 16)
-            data = b""
-            for offset in range(0, len, max_block_size):
-                length_to_read = min(len - offset, max_block_size)
-                block = os.pread(self.file, length_to_read, hva + offset)
-                data += block
-            return data
-        except Exception as e:
-            msg = f"Physical address ({hex(phys_addr)}, +{hex(len)}) is not accessible. Reason: {e}. gpa2hva result: {res}"
-            raise OSError(msg)
-
-class PageTableDump(gdb.Command):
-    """
-    GDB pt-dump: command for inspecting VM page tables.
-    Arguments:
-        -filter FILTER [FILTER ...]
-            Specify filters for the recorded pages.
-            x86_64 Supported filters:
-                w: is writeable.
-                x: is executable
-                w|x: is writeable or executable
-                ro: read-only
-                u: user-space page
-                s: supervisor page
-                wb: write-back
-                uc: uncacheable
-
-             aarch64- and riscv64-supported filters:
-                w: is writeable.
-                x: is executable
-                w|x: is writeable or executable
-                ro: read-only
-                u: user-space page
-                s: supervisor page
-
-        -range START_ADDR END_ADDR
-            Will filter-out virtual memory ranges which start at a position in [START_ADDR, END_ADDR]
-        -has ADDR
-            Will filter-out virtual memory ranges which contain ADDR
-        -before ADDR
-            Will select virtual memory ranges which start <ADDR
-        -after ADDR
-            Will select virtual memory ranges which start >=ADDR
-        -ss "STRING"
-            Searches for the string STRING in the ranges after filtering
-        -sb BYTESTRING
-            Searches for the byte-string BYTESTRING in the ranges after filtering
-        -s8 VALUE
-            Searches for the value VALUE in the ranges after filtering
-            VALUE should fit in 8 bytes.
-        -s4 VALUE
-            Searches for the value VALUE in the ranges after filtering
-            VALUE should fit in 4 bytes.
-        -align ALIGNMENT [OFFSET]
-            When searching, it will print out addresses which are aligned to ALIGNMENT.
-            If offset is provided, then the check would be performed as (ADDR - OFFSET) % ALIGNMENT.
-            It can be useful when searching for content in a particular SLAB.
-        -kaslr
-            Print KASLR-relevant information like the image offsets and phys map base.
-        -kaslr_leaks
-            Searchers for values which disclose KASLR offsets.
-        -save
-            Cache the recorded page table for that address after traversing the hierachy.
-            This will yield speed-up when printing the page table again.
-        -list
-            List the cached page tables.
-        -clear
-            Clear all saved page tables.
-        -info
-            Print arch register information.
-        -o FILE_NAME
-            Store the output from the current command to a file with name FILE_NAME.
-            This may be useful when the a lot of data is produced, e.g. full page table.
-        -find_alias
-            Experimental feature and currently slow. Searches for aliases ranges in virtual memory.
-            Ranges are aliased if they point to the the same physical memory. This can be useful if one
-            is searching for R/RX memory which is writeable through some other address.
-            Another interesting option is to find alias for memory mapped in user space and kernel space.
-            TODO: This feature will be reworked for usability and performance in the near future.
-        -force_traverse_all
-            Forces the traversal of any page table entry (pml4, pdp, ...) even if a duplicate entry has
-            already been trarversed. Using this option bypasses an optimization which discards already
-            traversed duplicate entries. Expect that using this option would render pt unusable for
-            windows VMs.
-        -phys_verbose
-            Prints the start physical address for the printed virtual ranges. This argument further
-            restricts the merging of virtual ranges by requiring that merged ranges need to also be
-            physically contiguous. Using this range leads to more verbose output.
-
-    Architecture-specific arguments:
-        - X86-32 / X86-64
-            `-cr3 HEX_ADDR`
-                The GPA of the page table. If not used, the script will use the architectural
-                register (e.g. cr3).
-
-        - aarch64
-            `-ttbr0_el1 HEX_ADDR`
-                The GPA of the TTBR0_EL1 register.
-            `-ttbr1_el1 HEX_ADDR`
-                The GPA of the TTBR1_EL1 register.
-
-        - riscv64
-            `-satp HEX_ADDR`
-                The GPA of the SATP register.
-
-    Example usage:
-        `pt -save -filter s w|x wb`
-            Traverse the current page table and then save it. When returning the result,
-            filter the pages to be marked as supervisor, be writeable or executable, and marked as
-            write-back.
-        `pt -filter w x`
-            Traverse the current page table and print out mappings which are both writeable and
-            executable.
-        `pt -cr3 0x4000`
-            Traverse the page table at guest physical address 0x4000. Don't save it.
-        `pt -save -kaslr`
-            Traverse page tables, save them and print kaslr information.
-        `pt -ss "Linux 4."`
-            Search for the string Linux.
-        `pt -sb da87374107`
-            Search for the byte-string da87374107.
-        `pt -s8 0xaabbccdd`
-            Search for the 8-byte-long value 0xaabbccdd.
-        `pt -has 0xffffffffaaf629f7`
-            Print information about the mapping which covers the address 0xffffffffaaf629f7.
-    """
-    def __init__(self):
-        super(PageTableDump, self).__init__("pt", gdb.COMMAND_USER)
-        self.pid = -1
-
-    def lazy_init(self):
-        # Get quick access to physical memory.
-        self.pid = get_qemu_pid()
-        self.phys_mem = VMPhysMem(self.pid)
-
-        self.backend = None
-        arch = gdb.execute("show architecture", to_string = True)
-        if "aarch64" in arch:
-            self.backend = PT_Aarch64_Backend(self.phys_mem)
-        elif "x86" in arch or "x64" in arch:
-            self.backend = PT_x86_64_Backend(self.phys_mem)
-        elif "riscv:rv64" in arch:
-            self.backend = PT_RiscV64_Backend(self.phys_mem)
-        else:
-            raise Exception(f"Unknown arch. Message: {arch}")
+    def __init__(self, machine_backend, arch_backend):
+        self.machine_backend = machine_backend
+        self.arch_backend = arch_backend
 
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("-save", action="store_true")
@@ -238,24 +38,44 @@ class PageTableDump(gdb.Command):
         self.parser.add_argument("-find_alias", action="store_true")
         self.parser.add_argument("-force_traverse_all", action="store_true")
 
-        if self.backend.get_arch() == "x86_64" or self.backend.get_arch() == "x86_32":
+        if self.arch_backend.get_arch() == "x86_64" or self.arch_backend.get_arch() == "x86_32":
             self.parser.add_argument("-cr3", nargs=1)
 
-        if self.backend.get_arch() == "aarch64":
+        if self.arch_backend.get_arch() == "aarch64":
             self.parser.add_argument("-ttbr0_el1", nargs=1)
             self.parser.add_argument("-ttbr1_el1", nargs=1)
 
-        if self.backend.get_arch() == "riscv64":
+        if self.arch_backend.get_arch() == "riscv64":
             self.parser.add_argument("-satp", nargs=1)
 
         self.cache = dict()
-
-        self.init = True
 
     def print_cache(self):
         print("Cache:")
         for address in self.cache:
             print(f"\t{hex(address)}")
+
+    def handle_command_wrapper(self, argv):
+        args = None
+        try:
+            args = self.parser.parse_args(argv)
+        except:
+            return None
+
+        saved_stdout = None
+        if args.o:
+            saved_stdout = sys.stdout
+            sys.stdout = open(args.o[0], "w+")
+
+        try:
+            self.handle_command(args)
+        except Exception as e:
+            print(f"Exception: {str(e)}")
+            print(f"Stack trace:\n{traceback.format_exc()}")
+        finally:
+            if saved_stdout:
+                sys.stdout.close()
+                sys.stdout = saved_stdout
 
     def handle_command(self, args):
         if args.list:
@@ -295,7 +115,7 @@ class PageTableDump(gdb.Command):
         page_ranges = None
         page_ranges_filtered = None
         if requires_page_table_parsing:
-            page_ranges = self.backend.parse_tables(self.cache, args)
+            page_ranges = self.arch_backend.parse_tables(self.cache, args)
             compound_filter, (min_address, max_address) = self.parse_filter_args(args)
             page_ranges_filtered = list(filter(compound_filter, page_ranges))
             # Perform cut-off of start and end.
@@ -311,66 +131,35 @@ class PageTableDump(gdb.Command):
             if page_ranges_filtered:
                 aligned_to = args.align[0] if args.align else 1
                 aligned_offset = args.align[1] if args.align and len(args.align) == 2 else 0
-                search_results = search_memory(self.phys_mem, page_ranges_filtered, to_search, to_search_num, aligned_to, aligned_offset)
+                search_results = search_memory(self.machine_backend, page_ranges_filtered, to_search, to_search_num, aligned_to, aligned_offset)
                 for entry in search_results:
                     print("Found at " + hex(entry[0]) + " in " + entry[1].to_string(args.phys_verbose))
             else:
                 print("Not found")
         elif args.walk:
-            walk = self.backend.walk(args.walk[0])
+            walk = self.arch_backend.walk(args.walk[0])
             print(walk)
         elif args.kaslr:
-            self.backend.print_kaslr_information(page_ranges)
+            self.arch_backend.print_kaslr_information(page_ranges)
         elif args.kaslr_leaks:
             def inner_find_leaks(x, off):
                 top = (x >> (off * 8)).to_bytes(8 - off, 'little')
                 num_entries = 10
-                entries = search_memory(self.phys_mem, page_ranges_filtered, top, num_entries, 1, 0)
+                entries = search_memory(self.machine_backend, page_ranges_filtered, top, num_entries, 1, 0)
                 if entries:
                     print(f"Search for {hex(x)}")
                     for entry in entries:
                         print("Found at " + hex(entry[0] - off) + " in " + entry[1].to_string(args.phys_verbose))
-            leaks = self.backend.print_kaslr_information(page_ranges, False)
+            leaks = self.arch_backend.print_kaslr_information(page_ranges, False)
             if leaks:
                 inner_find_leaks(leaks[0], 3)
                 inner_find_leaks(leaks[1], 5)
         elif args.info:
-            self.backend.print_stats()
+            self.arch_backend.print_stats()
         elif args.find_alias:
             find_aliases(page_ranges, args.phys_verbose)
         else:
-            self.backend.print_table(page_ranges_filtered, phys_verbose=args.phys_verbose)
-
-    def invoke(self, arg, from_tty):
-        try:
-            curr_pid = get_qemu_pid()
-            if curr_pid != self.pid:
-                self.lazy_init()
-        except:
-            print("Cannot get qemu-system pid")
-            return
-
-        argv = gdb.string_to_argv(arg)
-        args = None
-        try:
-            args = self.parser.parse_args(argv)
-        except:
-            return None
-
-        saved_stdout = None
-        if args.o:
-            saved_stdout = sys.stdout
-            sys.stdout = open(args.o[0], "w+")
-
-        try:
-            self.handle_command(args)
-        except Exception as e:
-            print(f"Exception: {str(e)}")
-            print(f"Stack trace:\n{traceback.format_exc()}")
-        finally:
-            if saved_stdout:
-                sys.stdout.close()
-                sys.stdout = saved_stdout
+            self.arch_backend.print_table(page_ranges_filtered, phys_verbose=args.phys_verbose) 
 
     def parse_filter_args(self, args):
         filters = []
@@ -412,25 +201,26 @@ class PageTableDump(gdb.Command):
                 has_user_filter = True
             for f in args.filter:
                 if f == "w":
-                    filters.append(self.backend.get_filter_is_writeable(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_writeable(has_superuser_filter, has_user_filter))
                 elif f == "_w":
-                    filters.append(self.backend.get_filter_is_not_writeable(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_not_writeable(has_superuser_filter, has_user_filter))
                 elif f == "x":
-                    filters.append(self.backend.get_filter_is_executable(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_executable(has_superuser_filter, has_user_filter))
                 elif f == "_x":
-                    filters.append(self.backend.get_filter_is_not_executable(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_not_executable(has_superuser_filter, has_user_filter))
                 elif f == "w|x" or f == "x|w":
-                    filters.append(self.backend.get_filter_is_writeable_or_executable(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_writeable_or_executable(has_superuser_filter, has_user_filter))
                 elif f == "u":
-                    filters.append(self.backend.get_filter_is_user_page(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_user_page(has_superuser_filter, has_user_filter))
                 elif f == "s":
-                    filters.append(self.backend.get_filter_is_superuser_page(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_superuser_page(has_superuser_filter, has_user_filter))
                 elif f == "ro":
-                    filters.append(self.backend.get_filter_is_read_only_page(has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_is_read_only_page(has_superuser_filter, has_user_filter))
                 elif f in ["wb", "_wb", "uc", "_uc"]:
-                    filters.append(self.backend.get_filter_architecture_specific(f, has_superuser_filter, has_user_filter))
+                    filters.append(self.arch_backend.get_filter_architecture_specific(f, has_superuser_filter, has_user_filter))
                 else:
                     print(f"Unknown filter: {f}")
                     return
 
         return (create_compound_filter(filters), (min_address, max_address))
+

--- a/pt/pt_aarch64_definitions.py
+++ b/pt/pt_aarch64_definitions.py
@@ -4,8 +4,8 @@ from pt.pt_register import *
 # I hope this doesn't break any license. Please don't sue :(
 
 class PT_TCR(PT_Register):
-    def __init__(self):
-        super(PT_TCR, self).__init__("TCR_EL1", "Translation Control Register EL1 (TCR EL1)")
+    def __init__(self, machine):
+        super(PT_TCR, self).__init__(machine, "TCR_EL1", "Translation Control Register EL1 (TCR EL1)")
         self.add_range("T0SZ", 0, 5, lambda x: f"{x} bits are truncated. TTBR0_EL1 addresses {64 - x} bits.")
         self.add_range("EPD0", 7, 7, PT_Decipher_Meaning_Match( \
             {0: "Perform translation table walk using TTBR0_EL1", \
@@ -57,4 +57,3 @@ class PT_TCR(PT_Register):
             {0: "Top Byte used in the address calculation.",
              1: "Top Byte ignored in the address calculation."}))
  
-pt_tcr = PT_TCR()

--- a/pt/pt_register.py
+++ b/pt/pt_register.py
@@ -1,4 +1,3 @@
-import gdb
 from collections import namedtuple
 from pt.pt_common import *
 
@@ -34,7 +33,8 @@ class PT_Decipher_Meaning_Match:
 PT_Decipher_Meaning_Passthrough = lambda x: x
 
 class PT_Register:
-    def __init__(self, register, name):
+    def __init__(self, machine, register, name):
+        self.machine = machine
         self.register = register
         self.name = name
         self.ranges_dict = {}
@@ -43,7 +43,7 @@ class PT_Register:
         self.ranges_dict[name] = PT_Register_Range(name = name, low = low, high = high, func = decipher_meaning)
 
     def check(self):
-        reg_value = int(gdb.parse_and_eval(f"${self.register}").cast(gdb.lookup_type("unsigned long")))
+        reg_value = self.machine.read_register(f"${self.register}")
         kv = dict()
         for key in self.ranges_dict:
             r = self.ranges_dict[key]

--- a/pt/pt_riscv64_parse.py
+++ b/pt/pt_riscv64_parse.py
@@ -4,18 +4,6 @@ from pt.pt_constants import *
 
 import math
 
-def get_address_space_size_from_mode(mode_value):
-    if mode_value == 8:
-        return 39
-    elif mode_value == 9:
-        return 48
-    elif mode_value == 10:
-        return 57
-    elif mode_value == 11:
-        return 64
-    else:
-        raise Exception(f"Unknown mode: {hex(mode_value)}")
-
 class Riscv64_Page():
     def __init__(self, va, phys, size, readable, writeable, executable, user):
         self.va = va
@@ -27,10 +15,10 @@ class Riscv64_Page():
         self.phys = [phys]
         self.sizes = [size]
 
-    def read_memory(self, phys_mem):
+    def read_memory(self, machine):
         memory = b""
         for phys_range_start, phys_range_size in zip(self.phys, self.sizes):
-            memory += phys_mem.read(phys_range_start, phys_range_size)
+            memory += machine.read_physical_memory(phys_range_start, phys_range_size)
         return memory
 
     def cut_before(self, va):
@@ -73,71 +61,82 @@ class Riscv64_Page():
 
         return res
 
-def riscv64_semantically_similar(p1, p2) -> bool:
-    return p1.x == p2.x and p1.w == p2.w and p1.r == p2.r and p1.s == p2.s
-
-def parse_entries(phys_mem, table, as_size, lvl):
-    dirs = []
-    pages = []
-    entries = []
-    try:
-        entries = split_range_into_int_values(read_page(phys_mem, table.phys[0]), 8)
-    except:
-        pass
-    for i, pa in enumerate(entries):
-        valid = extract(pa, 0, 0)
-        if valid:
-            is_leaf = (extract(pa, 1, 3) != 0)
-            address_contrib = (i << (as_size - lvl * 9))
-            child_va = table.va | address_contrib
-            phys_addr = extract(pa, 10, 53) << 12
-            if is_leaf:
-                size = 1 << (as_size - lvl * 9)
-                readable = extract(pa, 1, 1)
-                writeable = extract(pa, 2, 2)
-                executable = extract(pa, 3, 3)
-                user_accessible = extract(pa, 4, 4)
-                pages.append(Riscv64_Page(child_va, phys_addr, size, readable, writeable, executable, user_accessible))
-            else:
-                dirs.append(Riscv64_Page(child_va, phys_addr, None, None, None, None, None))
-    return dirs, pages
-
-
-def traverse_table(phys_mem, pt_addr, as_size):
-    root = Riscv64_Page(0, pt_addr, 0, 0, 0, 0, 0)
-    directories, leafs = parse_entries(phys_mem, root, as_size, lvl=1)
-
-    lvl = 2
-    while len(directories) != 0:
-        directories_cur_lvl = []
-        for tmp_tb in directories:
-            tmp_dirs, tmp_leafs = parse_entries(phys_mem, tmp_tb, as_size, lvl=lvl)
-            directories_cur_lvl.extend(tmp_dirs)
-            leafs.extend(tmp_leafs)
-        lvl = lvl + 1
-        directories = directories_cur_lvl
-
-    for leaf in leafs:
-        leaf.va = make_canonical(leaf.va, as_size)
-
-    return leafs
-
-def print_stats():
-    return
-
 class PT_RiscV64_Backend(PTArchBackend):
-    def __init__(self, phys_mem):
-        self.phys_mem = phys_mem
+    def __init__(self, machine):
+        self.machine = machine
 
     def get_arch(self):
         return "riscv64"
+
+    def riscv64_semantically_similar(p1, p2) -> bool:
+        return p1.x == p2.x and p1.w == p2.w and p1.r == p2.r and p1.s == p2.s
+
+    def parse_entries(self, table, as_size, lvl):
+        dirs = []
+        pages = []
+        entries = []
+        try:
+            entries = split_range_into_int_values(read_page(self.machine, table.phys[0]), 8)
+        except:
+            pass
+        for i, pa in enumerate(entries):
+            valid = extract(pa, 0, 0)
+            if valid:
+                is_leaf = (extract(pa, 1, 3) != 0)
+                address_contrib = (i << (as_size - lvl * 9))
+                child_va = table.va | address_contrib
+                phys_addr = extract(pa, 10, 53) << 12
+                if is_leaf:
+                    size = 1 << (as_size - lvl * 9)
+                    readable = extract(pa, 1, 1)
+                    writeable = extract(pa, 2, 2)
+                    executable = extract(pa, 3, 3)
+                    user_accessible = extract(pa, 4, 4)
+                    pages.append(Riscv64_Page(child_va, phys_addr, size, readable, writeable, executable, user_accessible))
+                else:
+                    dirs.append(Riscv64_Page(child_va, phys_addr, None, None, None, None, None))
+        return dirs, pages
+
+    def traverse_table(self, pt_addr, as_size):
+        root = Riscv64_Page(0, pt_addr, 0, 0, 0, 0, 0)
+        directories, leafs = self.parse_entries(root, as_size, lvl=1)
+
+        lvl = 2
+        while len(directories) != 0:
+            directories_cur_lvl = []
+            for tmp_tb in directories:
+                tmp_dirs, tmp_leafs = self.parse_entries(tmp_tb, as_size, lvl=lvl)
+                directories_cur_lvl.extend(tmp_dirs)
+                leafs.extend(tmp_leafs)
+            lvl = lvl + 1
+            directories = directories_cur_lvl
+
+        for leaf in leafs:
+            leaf.va = make_canonical(leaf.va, as_size)
+
+        return leafs
+
+    def print_stats(self):
+        raise Exception("Unimplemented")
+
+    def get_address_space_size_from_mode(self, mode_value):
+        if mode_value == 8:
+            return 39
+        elif mode_value == 9:
+            return 48
+        elif mode_value == 10:
+            return 57
+        elif mode_value == 11:
+            return 64
+        else:
+            raise Exception(f"Unknown mode: {hex(mode_value)}")
 
     def walk(self, va):
         entry_size = 8
         num_entries_per_page = int(4096 / entry_size)
         bits_per_level = int(math.log2(num_entries_per_page))
 
-        satp = int(gdb.parse_and_eval("$satp").cast(gdb.lookup_type("unsigned long")))
+        satp = self.machine.read_register("$satp")
         pt_addr = extract(satp, 0, 43) << 12
         mode_value = extract(satp, 60, 63)
         as_size = get_address_space_size_from_mode(mode_value)
@@ -151,7 +150,7 @@ class PT_RiscV64_Backend(PTArchBackend):
             low_bit = top_bit - bits_per_level + 1
             entry_index = extract(va, low_bit, top_bit)
             entry_page_pa = pt_addr + entry_index * entry_size
-            entry_value = int.from_bytes(self.phys_mem.read(entry_page_pa, entry_size), 'little')
+            entry_value = int.from_bytes(self.machine.read_physical_memory(entry_page_pa, entry_size), 'little')
             entry_value_pa_no_meta = (extract(entry_value, 10, 53)) << 12
             meta_bits = extract_no_shift(entry_value, 0, 9)
             pt_walk.add_stage(f"Level{iter}", entry_index, entry_value_pa_no_meta, meta_bits)
@@ -203,7 +202,7 @@ class PT_RiscV64_Backend(PTArchBackend):
         if satp:
             satp = int(satp[0], 16)
         else:
-            satp = int(gdb.parse_and_eval("$satp").cast(gdb.lookup_type("unsigned long")))
+            satp = self.machine.read_register("$satp")
 
         all_blocks = None
 
@@ -211,17 +210,17 @@ class PT_RiscV64_Backend(PTArchBackend):
             all_blocks = cache[satp]
         else:
             mode_value = extract(satp, 60, 63)
-            as_size = get_address_space_size_from_mode(mode_value)
+            as_size = self.get_address_space_size_from_mode(mode_value)
             pt_base = extract(satp, 0, 43) << 12
-            all_blocks = traverse_table(self.phys_mem, pt_base, as_size)
-            all_blocks = optimize([], [], all_blocks, riscv64_semantically_similar, requires_physical_contiguity)
+            all_blocks = self.traverse_table(pt_base, as_size)
+            all_blocks = optimize([], [], all_blocks, PT_RiscV64_Backend.riscv64_semantically_similar, requires_physical_contiguity)
 
         if args.save:
             cache[satp] = all_blocks
 
         return all_blocks
 
-    def print_kaslr_information(self, table, phys_verbose):
+    def print_kaslr_information(self, table, should_print = True, phys_verbose = False):
         return None
 
     def print_table(self, table, phys_verbose):
@@ -236,8 +235,4 @@ class PT_RiscV64_Backend(PTArchBackend):
         for page in table:
             print(page.to_string(phys_verbose))
         return None
-
-    def print_stats(self):
-        print_stats()
-        return
 

--- a/pt/pt_x86_64_parse.py
+++ b/pt/pt_x86_64_parse.py
@@ -1,5 +1,5 @@
 from pt.pt_x86_64_definitions import *
-import pt.pt_x86_msr as x86_msr
+from pt.pt_x86_msr import *
 from pt.pt_common import *
 from pt.pt_constants import *
 from pt.pt_arch_backend import PTArchBackend
@@ -7,107 +7,6 @@ from abc import ABC
 from abc import abstractmethod
 
 import math
-
-def retrieve_pse():
-    uses_pse = ((int(gdb.parse_and_eval("$cr4").cast(gdb.lookup_type("unsigned long"))) >> 4) & 0x1) == 0x1
-    return uses_pse
-
-def retrieve_pae():
-    uses_pae = ((int(gdb.parse_and_eval("$cr4").cast(gdb.lookup_type("unsigned long"))) >> 5) & 0x1) == 0x1
-    return uses_pae
-
-def has_paging_enabled():
-    uses_paging = ((int(gdb.parse_and_eval("$cr0").cast(gdb.lookup_type("unsigned long"))) >> 31) & 0x1) == 0x1
-    return uses_paging
-
-def parse_pml4(phys_mem, addr, force_traverse_all):
-    entries = []
-    entry_size = 8
-    try:
-        values = split_range_into_int_values(read_page(phys_mem, addr), entry_size)
-    except:
-        return entries
-    pml4_cache = {}
-    for u, value in enumerate(values):
-        if (value & 0x1) != 0: # Page must be present
-            if force_traverse_all or value not in pml4_cache:
-                entry = PML4_Entry(value, u)
-                entries.append(entry)
-                pml4_cache[value] = entry
-    return entries
-
-def parse_pml4es(phys_mem, pml4es, force_traverse_all, entry_size):
-    entries = []
-    for pml4e in pml4es:
-        pdpe = parse_pdp(phys_mem, pml4e, force_traverse_all, 4096, entry_size)
-        entries.extend(pdpe)
-    return entries
-
-def parse_pdp(phys_mem, pml4e, force_traverse_all, size, entry_size):
-    entries = []
-    try:
-        values = split_range_into_int_values(phys_mem.read(pml4e.pdp, size), entry_size)
-    except:
-        return entries
-    pdp_cache = {}
-    for u, value in enumerate(values):
-        if (value & 0x1) != 0:
-            if force_traverse_all or value not in pdp_cache:
-                entry = PDP_Entry(value, pml4e.virt_part, u)
-                entries.append(entry)
-                pdp_cache[value] = entry
-    return entries
-
-def parse_pdpes(phys_mem, pdpes, force_traverse_all, entry_size, pde_shift):
-    entries = []
-    pages = []
-    for pdpe in pdpes:
-        if pdpe.large_page == False:
-            pdes = parse_pd(phys_mem, pdpe, force_traverse_all, entry_size, pde_shift)
-            entries.extend(pdes)
-        else:
-            page = create_page_from_pdpe(pdpe)
-            pages.append(page)
-    return entries, pages
-
-def parse_pd(phys_mem, pdpe, force_traverse_all, entry_size, pde_shift):
-    entries = []
-    try:
-        values = split_range_into_int_values(read_page(phys_mem, pdpe.pd), entry_size)
-    except:
-        return entries
-    pd_cache = {}
-    for u, value in enumerate(values):
-        if (value & 0x1) != 0:
-            if force_traverse_all or value not in pd_cache:
-                entry = PD_Entry(value, pdpe.virt_part, u, pde_shift)
-                entries.append(entry)
-                pd_cache[value] = entry
-    return entries
-
-def parse_pdes(phys_mem, pdes, entry_size=8):
-    entries = []
-    pages = []
-    for pde in pdes:
-        if pde.big_page == False:
-            ptes = parse_pt(phys_mem, pde, entry_size)
-            entries.extend(ptes)
-        else:
-            page = create_page_from_pde(pde)
-            pages.append(page)
-    return entries, pages
-
-def parse_pt(phys_mem, pde, entry_size=8):
-    entries = []
-    try:
-        values = split_range_into_int_values(read_page(phys_mem, pde.pt), entry_size)
-    except:
-        return entries
-    for u, value in enumerate(values):
-        if (value & 0x1) != 0:
-            entry = PT_Entry(value, pde.virt_part, u)
-            entries.append(entry)
-    return entries
 
 class PT_x86_Common_Backend():
  
@@ -160,8 +59,8 @@ class PT_x86_Common_Backend():
             print(page.to_string(phys_verbose))
 
     def print_stats(self):
-        print(x86_msr.pt_cr0.check())
-        print(x86_msr.pt_cr4.check())
+        print(self.pt_cr0.check())
+        print(self.pt_cr4.check())
 
     @abstractmethod
     def get_arch(self):
@@ -169,17 +68,17 @@ class PT_x86_Common_Backend():
 
     def walk(self, va):
 
-        if has_paging_enabled() == False:
+        if self.has_paging_enabled() == False:
             raise Exception("Paging is not enabled")
 
         entry_size = self.get_entry_size()
         num_entries_per_page = int(4096 / entry_size)
         bits_per_level = int(math.log2(num_entries_per_page))
 
-        pse = retrieve_pse()
+        pse = self.retrieve_pse()
         pse_ignore = self.get_arch() == "x86_64"
 
-        pt_addr = int(gdb.parse_and_eval("$cr3").cast(gdb.lookup_type("unsigned long")))
+        pt_addr = self.machine.read_register("$cr3")
 
         pt_walk = PageTableWalkInfo(va)
         pt_walk.add_register_stage("CR3", pt_addr)
@@ -198,7 +97,7 @@ class PT_x86_Common_Backend():
             page_pa = cur_phys_addr & ~0xFFF
             entry_index = extract(va, top_va_bit - bits_per_level + 1, top_va_bit)
             entry_page_pa = page_pa + entry_index * entry_size
-            entry_value = int.from_bytes(self.phys_mem.read(entry_page_pa, entry_size), 'little')
+            entry_value = int.from_bytes(self.machine.read_physical_memory(entry_page_pa, entry_size), 'little')
             entry_value_pa_no_meta = extract_no_shift(entry_value, 12, 47)
             meta_bits = extract_no_shift(entry_value, 0, 11)
 
@@ -219,11 +118,10 @@ class PT_x86_Common_Backend():
     def print_kaslr_information(self, table, should_print=True, phys_verbose=False):
         potential_base_filter = lambda p: p.x and p.s and p.phys[0] % PT_SIZE_2MIB == 0
         tmp = list(filter(potential_base_filter, table))
-        th = gdb.selected_inferior()
         found_page = None
 
         for page in tmp:
-            first_byte = th.read_memory(page.va, 1)
+            first_byte = self.machine.read_physical_memory(page.phys[0], 1)
             if first_byte[0] == b'\x48':
                 found_page = page
                 break
@@ -235,9 +133,9 @@ class PT_x86_Common_Backend():
             stdout_output += "\tVirt: " + found_page.to_string(phys_verbose) + "\n"
             stdout_output += "\tPhys: " + hex(found_page.phys[0]) + "\n"
             kaslr_addresses.append(found_page.va)
-            first_bytes = th.read_memory(page.va, 32).tobytes()
+            first_bytes = self.machine.read_physical_memory(page.phys[0], 32).tobytes()
             page_ranges_subset = filter(lambda page: not page.x and page.s and page.va % PT_SIZE_2MIB == 0, table)
-            search_res_iter = search_memory(self.phys_mem, page_ranges_subset, first_bytes, 1, 1, 0)
+            search_res_iter = search_memory(self.physical_memory, page_ranges_subset, first_bytes, 1, 1, 0)
             if search_res_iter == None:
                 print("Phys map was not found")
             else:
@@ -253,17 +151,119 @@ class PT_x86_Common_Backend():
             print(stdout_output)
         return kaslr_addresses
 
+    def retrieve_pse(self):
+        return (self.machine.read_register("$cr4") >> 4) & 0x1 == 0x1
+
+    def retrieve_pae(self):
+        return (self.machine.read_register("$cr4") >> 5) & 0x1 == 0x1
+
+    def has_paging_enabled(self):
+        return (self.machine.read_register("$cr0") >> 31) & 0x1 == 0x1
+
+    def parse_pml4(self, addr, force_traverse_all):
+        entries = []
+        entry_size = 8
+        try:
+            values = split_range_into_int_values(read_page(self.machine, addr), entry_size)
+        except:
+            return entries
+        pml4_cache = {}
+        for u, value in enumerate(values):
+            if (value & 0x1) != 0: # Page must be present
+                if force_traverse_all or value not in pml4_cache:
+                    entry = PML4_Entry(value, u)
+                    entries.append(entry)
+                    pml4_cache[value] = entry
+        return entries
+
+    def parse_pml4es(self, pml4es, force_traverse_all, entry_size):
+        entries = []
+        for pml4e in pml4es:
+            pdpe = self.parse_pdp(pml4e, force_traverse_all, 4096, entry_size)
+            entries.extend(pdpe)
+        return entries
+
+    def parse_pdp(self, pml4e, force_traverse_all, size, entry_size):
+        entries = []
+        try:
+            values = split_range_into_int_values(self.machine.read_physical_memory(pml4e.pdp, size), entry_size)
+        except:
+            return entries
+        pdp_cache = {}
+        for u, value in enumerate(values):
+            if (value & 0x1) != 0:
+                if force_traverse_all or value not in pdp_cache:
+                    entry = PDP_Entry(value, pml4e.virt_part, u)
+                    entries.append(entry)
+                    pdp_cache[value] = entry
+        return entries
+
+    def parse_pdpes(self, pdpes, force_traverse_all, entry_size, pde_shift):
+        entries = []
+        pages = []
+        for pdpe in pdpes:
+            if pdpe.large_page == False:
+                pdes = self.parse_pd(pdpe, force_traverse_all, entry_size, pde_shift)
+                entries.extend(pdes)
+            else:
+                page = create_page_from_pdpe(pdpe)
+                pages.append(page)
+        return entries, pages
+
+    def parse_pd(self, pdpe, force_traverse_all, entry_size, pde_shift):
+        entries = []
+        try:
+            values = split_range_into_int_values(read_page(self.machine, pdpe.pd), entry_size)
+        except:
+            return entries
+        pd_cache = {}
+        for u, value in enumerate(values):
+            if (value & 0x1) != 0:
+                if force_traverse_all or value not in pd_cache:
+                    entry = PD_Entry(value, pdpe.virt_part, u, pde_shift)
+                    entries.append(entry)
+                    pd_cache[value] = entry
+        return entries
+
+    def parse_pdes(self, pdes, entry_size=8):
+        entries = []
+        pages = []
+        for pde in pdes:
+            if pde.big_page == False:
+                ptes = self.parse_pt(pde, entry_size)
+                entries.extend(ptes)
+            else:
+                page = create_page_from_pde(pde)
+                pages.append(page)
+        return entries, pages
+
+    def parse_pt(self, pde, entry_size=8):
+        entries = []
+        try:
+            values = split_range_into_int_values(read_page(self.machine, pde.pt), entry_size)
+        except:
+            return entries
+        for u, value in enumerate(values):
+            if (value & 0x1) != 0:
+                entry = PT_Entry(value, pde.virt_part, u)
+                entries.append(entry)
+        return entries
 
 class PT_x86_64_Backend(PT_x86_Common_Backend, PTArchBackend):
 
     def get_arch(self):
         return "x86_64"
 
-    def __init__(self, phys_mem):
-        self.phys_mem = phys_mem
+    def __init__(self, machine):
+        self.machine = machine
+        self.init_registers()
+
+    def init_registers(self):
+        self.pt_cr0 = PT_CR0(self.machine)
+        self.pt_cr4 = PT_CR4(self.machine)
 
     def is_long_mode_enabled(self):
-        efer = int(gdb.parse_and_eval("$efer").cast(gdb.lookup_type("unsigned long")))
+        efer = self.machine.read_register("$efer")
         long_mode_enabled = bool((efer >> 8) & 0x1)
         return long_mode_enabled
 
@@ -271,7 +271,7 @@ class PT_x86_64_Backend(PT_x86_Common_Backend, PTArchBackend):
         if self.is_long_mode_enabled():
             return 8
         else:
-            pae = retrieve_pae()
+            pae = self.retrieve_pae()
             return 8 if pae else 4
 
     def get_pde_shift(self):
@@ -297,11 +297,11 @@ class PT_x86_64_Backend(PT_x86_Common_Backend, PTArchBackend):
 
     def parse_tables(self, cache, args):
         # Check that paging is enabled, otherwise no point to continue.
-        if has_paging_enabled() == False:
+        if self.has_paging_enabled() == False:
             raise Exception("Paging is not enabled")
 
         # Check if long mode is enabled
-        efer = int(gdb.parse_and_eval("$efer").cast(gdb.lookup_type("unsigned long")))
+        efer = self.machine.read_register("$efer")
         long_mode_enabled = bool((efer >> 8) & 0x1)
 
         requires_physical_contiguity = args.phys_verbose
@@ -309,7 +309,7 @@ class PT_x86_64_Backend(PT_x86_Common_Backend, PTArchBackend):
         if args.cr3:
             pt_addr = int(args.cr3[0], 16)
         else:
-            pt_addr = int(gdb.parse_and_eval("$cr3").cast(gdb.lookup_type("unsigned long")))
+            pt_addr = self.machine.read_register("$cr3")
             # TODO: Check if these attribute bits in the cr3 need to be respected.
         pt_addr = pt_addr & (~0xfff)
 
@@ -320,10 +320,10 @@ class PT_x86_64_Backend(PT_x86_Common_Backend, PTArchBackend):
         elif long_mode_enabled:
             pde_shift = self.get_pde_shift()
             entry_size = self.get_entry_size()
-            pml4es = parse_pml4(self.phys_mem, pt_addr, args.force_traverse_all)
-            pdpes = parse_pml4es(self.phys_mem, pml4es, args.force_traverse_all, entry_size)
-            pdes, large_pages = parse_pdpes(self.phys_mem, pdpes, args.force_traverse_all, entry_size, pde_shift)
-            ptes, big_pages = parse_pdes(self.phys_mem, pdes)
+            pml4es = self.parse_pml4(pt_addr, args.force_traverse_all)
+            pdpes = self.parse_pml4es(pml4es, args.force_traverse_all, entry_size)
+            pdes, large_pages = self.parse_pdpes(pdpes, args.force_traverse_all, entry_size, pde_shift)
+            ptes, big_pages = self.parse_pdes(pdes)
             small_pages = []
             for pte in ptes:
                 small_pages.append(create_page_from_pte(pte))
@@ -337,12 +337,12 @@ class PT_x86_64_Backend(PT_x86_Common_Backend, PTArchBackend):
             if pae:
                 dummy_pml4 = PML4_Entry(pt_addr, 0)
                 num_entries = 4
-                pdpes = parse_pdp(self.phys_mem, dummy_pml4, args.force_traverse_all, num_entries * entry_size, entry_size)
+                pdpes = parse_pdp(dummy_pml4, args.force_traverse_all, num_entries * entry_size, entry_size)
             else:
                 pdpes = [PDP_Entry(pt_addr, 0, 0)]
 
-            pdes, large_pages = parse_pdpes(self.phys_mem, pdpes, args.force_traverse_all, entry_size, pde_shift)
-            ptes, big_pages = parse_pdes(self.phys_mem, pdes, entry_size)
+            pdes, large_pages = parse_pdpes(pdpes, args.force_traverse_all, entry_size, pde_shift)
+            ptes, big_pages = parse_pdes(pdes, entry_size)
             small_pages = []
             for pte in ptes:
                 small_pages.append(create_page_from_pte(pte))

--- a/pt/pt_x86_msr.py
+++ b/pt/pt_x86_msr.py
@@ -1,8 +1,8 @@
 from pt.pt_register import *
 
 class PT_CR0(PT_Register):
-    def __init__(self):
-        super(PT_CR0, self).__init__("cr0", "Control Register 0")
+    def __init__(self, machine):
+        super(PT_CR0, self).__init__(machine, "cr0", "Control Register 0")
         self.add_range("PE (Protected Mode Enable)", 0, 0, PT_Decipher_Meaning_Match({0: "Protected mode", 1: "Real mode"}))
         self.add_range("MP (Monitor co-processor)", 1, 1, PT_Decipher_Meaning_Passthrough)
         self.add_range("EM (Emulation)", 2, 2, PT_Decipher_Meaning_Match({1: "No x87 FPU present", 0: "x87 FPU present"}))
@@ -16,8 +16,8 @@ class PT_CR0(PT_Register):
         self.add_range("PG (Paging)", 31, 31, PT_Decipher_Meaning_Passthrough)
 
 class PT_CR4(PT_Register):
-    def __init__(self):
-        super(PT_CR4, self).__init__("cr4", "Control Register 4")
+    def __init__(self, machine):
+        super(PT_CR4, self).__init__(machine, "cr4", "Control Register 4")
         self.add_range("VME (Virtual 8086 Mode Extensions)", 0, 0, PT_Decipher_Meaning_Passthrough)
         self.add_range("PVI (Protected-model virtual interrupts)", 1, 1, PT_Decipher_Meaning_Passthrough)
         self.add_range("TSD (Time Stamp Disable)", 2, 2, PT_Decipher_Meaning_Passthrough)
@@ -39,7 +39,4 @@ class PT_CR4(PT_Register):
         self.add_range("SMEP", 20, 20, PT_Decipher_Meaning_Passthrough)
         self.add_range("SMAP", 21, 21, PT_Decipher_Meaning_Passthrough)
         self.add_range("PKE", 22, 22, PT_Decipher_Meaning_Passthrough)
-
-pt_cr0 = PT_CR0()
-pt_cr4 = PT_CR4()
 

--- a/pt_gdb/__init__.py
+++ b/pt_gdb/__init__.py
@@ -1,0 +1,1 @@
+from pt_gdb.pt_gdb import PageTableDumpGdbFrontend

--- a/pt_gdb/pt_gdb.py
+++ b/pt_gdb/pt_gdb.py
@@ -1,0 +1,237 @@
+from pt.machine import *
+from pt.pt import *
+from pt.pt_x86_64_parse import *
+from pt.pt_aarch64_parse import *
+from pt.pt_riscv64_parse import *
+
+import gdb
+import os
+import subprocess
+
+class QemuGdbMachine(Machine):
+
+    def __init__(self):
+        self.pid = QemuGdbMachine.get_qemu_pid()
+        self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
+        self.mem_size = os.fstat(self.file).st_size
+
+    def __close__(self):
+        if self.file:
+            os.close(self.file)
+
+    def read_virtual_memory(self, virtual_address, length):
+        th = gdb.selected_inferior()
+        return th.read_memory(virtual_address, length)
+
+    def read_physical_memory(self, physical_address, length):
+        res = gdb.execute(f"monitor gpa2hva {hex(physical_address)}", to_string = True)
+
+        # It's not possible to pread large sizes, so let's break the request
+        # into a few smaller ones.
+        max_block_size = 1024 * 1024 * 256
+        try:
+            hva = int(res.split(" ")[-1], 16)
+            data = b""
+            for offset in range(0, length, max_block_size):
+                length_to_read = min(length - offset, max_block_size)
+                block = os.pread(self.file, length_to_read, hva + offset)
+                data += block
+            return data
+        except Exception as e:
+            msg = f"Physical address ({hex(physical_address)}, +{hex(length)}) is not accessible. Reason: {e}. gpa2hva result: {res}"
+            raise OSError(msg)
+
+    def search_pids_for_file(pids, filename):
+        for pid in pids:
+            fd_dir = f"/proc/{pid}/fd"
+
+            try:
+                for fd in os.listdir(fd_dir):
+                    if os.readlink(f"{fd_dir}/{fd}") == filename:
+                        return pid
+            except FileNotFoundError:
+                # Either the process has gone or fds are changing, not our pid
+                pass
+            except PermissionError:
+                # Evade processes owned by other users
+                pass
+
+        return None
+
+    @staticmethod
+    def get_qemu_pid():
+        out = subprocess.check_output(["pgrep", "qemu-system"], encoding="utf8")
+        pids = out.strip().split('\n')
+
+        if len(pids) == 1:
+            return int(pids[0], 10)
+
+        # We add a chardev file backend (we dont add a fronted, so it doesn't affect
+        # the guest). We can then look through proc to find which process has the file
+        # open. This approach is agnostic to namespaces (pid, network and mount).
+        chardev_id = "gdb-pt-dump" + '-' + ''.join(random.choices(string.ascii_letters, k=16))
+        with tempfile.NamedTemporaryFile() as t:
+            gdb.execute(f"monitor chardev-add file,id={chardev_id},path={t.name}")
+            ret = QemuGdbMachine.search_pids_for_file(pids, t.name)
+            gdb.execute(f"monitor chardev-remove {chardev_id}")
+
+        if not ret:
+            raise Exception("Could not find qemu pid")
+
+        return int(ret, 10)
+
+    def read_register(self, register_name):
+        return int(gdb.parse_and_eval(register_name).cast(gdb.lookup_type("unsigned long")))
+
+class PageTableDumpGdbFrontend(gdb.Command):
+    """
+    GDB pt-dump: command for inspecting VM page tables.
+    Arguments:
+        -filter FILTER [FILTER ...]
+            Specify filters for the recorded pages.
+            x86_64 Supported filters:
+                w: is writeable.
+                x: is executable
+                w|x: is writeable or executable
+                ro: read-only
+                u: user-space page
+                s: supervisor page
+                wb: write-back
+                uc: uncacheable
+
+             aarch64- and riscv64-supported filters:
+                w: is writeable.
+                x: is executable
+                w|x: is writeable or executable
+                ro: read-only
+                u: user-space page
+                s: supervisor page
+
+        -range START_ADDR END_ADDR
+            Will filter-out virtual memory ranges which start at a position in [START_ADDR, END_ADDR]
+        -has ADDR
+            Will filter-out virtual memory ranges which contain ADDR
+        -before ADDR
+            Will select virtual memory ranges which start <ADDR
+        -after ADDR
+            Will select virtual memory ranges which start >=ADDR
+        -ss "STRING"
+            Searches for the string STRING in the ranges after filtering
+        -sb BYTESTRING
+            Searches for the byte-string BYTESTRING in the ranges after filtering
+        -s8 VALUE
+            Searches for the value VALUE in the ranges after filtering
+            VALUE should fit in 8 bytes.
+        -s4 VALUE
+            Searches for the value VALUE in the ranges after filtering
+            VALUE should fit in 4 bytes.
+        -align ALIGNMENT [OFFSET]
+            When searching, it will print out addresses which are aligned to ALIGNMENT.
+            If offset is provided, then the check would be performed as (ADDR - OFFSET) % ALIGNMENT.
+            It can be useful when searching for content in a particular SLAB.
+        -kaslr
+            Print KASLR-relevant information like the image offsets and phys map base.
+        -kaslr_leaks
+            Searchers for values which disclose KASLR offsets.
+        -save
+            Cache the recorded page table for that address after traversing the hierachy.
+            This will yield speed-up when printing the page table again.
+        -list
+            List the cached page tables.
+        -clear
+            Clear all saved page tables.
+        -info
+            Print arch register information.
+        -o FILE_NAME
+            Store the output from the current command to a file with name FILE_NAME.
+            This may be useful when the a lot of data is produced, e.g. full page table.
+        -find_alias
+            Experimental feature and currently slow. Searches for aliases ranges in virtual memory.
+            Ranges are aliased if they point to the the same physical memory. This can be useful if one
+            is searching for R/RX memory which is writeable through some other address.
+            Another interesting option is to find alias for memory mapped in user space and kernel space.
+            TODO: This feature will be reworked for usability and performance in the near future.
+        -force_traverse_all
+            Forces the traversal of any page table entry (pml4, pdp, ...) even if a duplicate entry has
+            already been trarversed. Using this option bypasses an optimization which discards already
+            traversed duplicate entries. Expect that using this option would render pt unusable for
+            windows VMs.
+        -phys_verbose
+            Prints the start physical address for the printed virtual ranges. This argument further
+            restricts the merging of virtual ranges by requiring that merged ranges need to also be
+            physically contiguous. Using this range leads to more verbose output.
+
+    Architecture-specific arguments:
+        - X86-32 / X86-64
+            `-cr3 HEX_ADDR`
+                The GPA of the page table. If not used, the script will use the architectural
+                register (e.g. cr3).
+
+        - aarch64
+            `-ttbr0_el1 HEX_ADDR`
+                The GPA of the TTBR0_EL1 register.
+            `-ttbr1_el1 HEX_ADDR`
+                The GPA of the TTBR1_EL1 register.
+
+        - riscv64
+            `-satp HEX_ADDR`
+                The GPA of the SATP register.
+
+    Example usage:
+        `pt -save -filter s w|x wb`
+            Traverse the current page table and then save it. When returning the result,
+            filter the pages to be marked as supervisor, be writeable or executable, and marked as
+            write-back.
+        `pt -filter w x`
+            Traverse the current page table and print out mappings which are both writeable and
+            executable.
+        `pt -cr3 0x4000`
+            Traverse the page table at guest physical address 0x4000. Don't save it.
+        `pt -save -kaslr`
+            Traverse page tables, save them and print kaslr information.
+        `pt -ss "Linux 4."`
+            Search for the string Linux.
+        `pt -sb da87374107`
+            Search for the byte-string da87374107.
+        `pt -s8 0xaabbccdd`
+            Search for the 8-byte-long value 0xaabbccdd.
+        `pt -has 0xffffffffaaf629f7`
+            Print information about the mapping which covers the address 0xffffffffaaf629f7.
+    """
+
+    def __init__(self):
+        super(PageTableDumpGdbFrontend, self).__init__("pt", gdb.COMMAND_USER)
+        self.pid = -1
+        self.pt = None
+
+    def lazy_init(self):
+
+        # Create machine backend
+        machine_backend = QemuGdbMachine()
+
+        # Create arch backend
+        arch = gdb.execute("show architecture", to_string = True)
+        arch_backend = None
+        if "aarch64" in arch:
+            arch_backend = PT_Aarch64_Backend(machine_backend)
+        elif "x86" in arch or "x64" in arch:
+            arch_backend = PT_x86_64_Backend(machine_backend)
+        elif "riscv:rv64" in arch:
+            arch_backend = PT_RiscV64_Backend(machine_backend)
+        else:
+            raise Exception(f"Unknown arch. Message: {arch}")
+
+        # Bring-up pt_dump
+        self.pt = PageTableDump(machine_backend, arch_backend)
+
+    def invoke(self, arg, from_tty):
+        try:
+            curr_pid = QemuGdbMachine.get_qemu_pid()
+            if curr_pid != self.pid:
+                self.lazy_init()
+        except Exception as e:
+            print("Cannot get qemu-system pid", e)
+            return
+
+        argv = gdb.string_to_argv(arg)
+        self.pt.handle_command_wrapper(argv)

--- a/pt_host.py
+++ b/pt_host.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+from pt.machine import *
+from pt.pt import *
+from pt.pt_x86_64_parse import *
+from pt.pt_aarch64_parse import *
+from pt.pt_riscv64_parse import *
+
+from bcc import BPF
+import fcntl
+import ctypes
+import threading
+import time
+
+import sys
+
+def read_address_from_kallsyms(searched_symb_name):
+    f = open("/proc/kallsyms", "r")
+    data = f.read()
+    f.close()
+    for line in data.split("\n"):
+        symb_addr, symb_type, symb_name = line.split(" ")
+        if searched_symb_name == symb_name:
+            return int(symb_addr, 16)
+    return None
+
+read_memory_bpf_program_src = open("pt_host/pt_host.bcc", "r").read()
+page_offset_base = read_address_from_kallsyms("page_offset_base")
+read_memory_bpf_program_src = read_memory_bpf_program_src.replace("$PAGE_OFFSET_BASE", hex(page_offset_base))
+read_memory_program = BPF(text=read_memory_bpf_program_src)
+
+def dummy_thread(event):
+    while not event.is_set():
+        time.sleep(0.01)
+
+def read_cr3(pid):
+    bpf_program = open("pt_host/pt_host_read_cr3.bcc", "r").read()
+    bpf_program = bpf_program.replace("$PID", pid)
+    page_offset_base = read_address_from_kallsyms("page_offset_base")
+    bpf_program = bpf_program.replace("$PAGE_OFFSET_BASE", hex(page_offset_base))
+    bpf = BPF(text=bpf_program)
+    bpf.attach_kprobe(event="finish_task_switch.isra.0", fn_name="read_cr3")
+    event = threading.Event()
+    th = threading.Thread(target=dummy_thread, args=(event,))
+    th.start()
+    cr3 = None
+    while cr3 == None or cr3 == 0:
+        (_, _, _, _, _, msg_b) = bpf.trace_fields()
+        msg = msg_b.decode('utf8')
+        if msg != "Done":
+            continue
+        cr3 = bpf["out_cr3"][0].value
+        if cr3 == 0:
+            continue
+    event.set()
+    th.join()
+    return cr3
+
+class HostMachine(Machine):
+
+    def __init__(self):
+        pass
+
+    def __close__(self):
+        pass
+
+    def read_virtual_memory(self, virtual_address, length):
+        raise Exception("Unimplemented")
+
+    def read_physical_memory(self, physical_address, length):
+        block_size = 0x1000
+        data = b""
+        for block_off in range(0, length, block_size):
+            block_len = min(block_size, length - block_off)
+            data += read_phys_memory(physical_address + block_off, block_len)
+        return data
+
+    def read_register(self, register_name):
+        value = None
+        if register_name == "$cr3":
+            #value = read_cr3(str(os.getpid()))
+            value = read_cr3(str(os.getpid()))
+        elif register_name == "$cr4":
+            value = (1 << 4) | (1 << 5) | (1 << 20) | (1 << 21)
+        elif register_name == "$cr0":
+            value = (1 << 0) | (1 << 16) | (1 << 31)
+        elif register_name == "$efer":
+            value = (1 << 8)
+        else:
+            raise Exception("Unimplemented register: " + register_name)
+        return value
+
+    def __init__(self):
+        pass
+
+class HostFrontend():
+    def __init__(self):
+
+        # Create machine backend
+        machine_backend = HostMachine()
+
+        # Create arch backend
+        arch_backend = PT_x86_64_Backend(machine_backend)
+
+        # Bring-up pt_dump
+        self.pt = PageTableDump(machine_backend, arch_backend)
+
+    def invoke(self, arg):
+        self.pt.handle_command_wrapper(arg)
+
+class Page(ctypes.Structure):
+    _fields_ = [('data', ctypes.c_char * 4096)]
+
+_attached = False
+
+def read_phys_memory(addr, len):
+    pid = os.getpid()
+
+    global _attached
+    if not _attached:
+        read_memory_program.get_table("in_pid")[ctypes.c_uint32(0)] = ctypes.c_uint32(pid)
+        read_memory_program.attach_kprobe(event=read_memory_program.get_syscall_fnname("ioctl"), fn_name="read_memory")
+        _attached = True
+
+    read_memory_program.get_table("in_phys_addr")[ctypes.c_uint32(0)] = ctypes.c_uint64(addr)
+    read_memory_program.get_table("in_phys_len")[ctypes.c_uint32(0)] = ctypes.c_uint32(len)
+    try:
+        fcntl.ioctl(0, 0xFEFEFEFE)
+    except:
+        pass
+    (_, _, _, _, _, msg_b) = read_memory_program.trace_fields()
+    msg = msg_b.decode('utf8')
+    assert(msg == "Done")
+    data = bytearray(read_memory_program["out_block"][0].data)
+    return data[:len]
+
+def main():
+    frontend = HostFrontend()
+    frontend.invoke(sys.argv[1:])
+
+if __name__ == "__main__":
+    main()
+

--- a/pt_host/pt_host.bcc
+++ b/pt_host/pt_host.bcc
@@ -1,0 +1,65 @@
+#include <linux/sched.h>
+#include <linux/mm.h>
+
+#define MAX_LEN ( 4096 )
+#define MAX_ELEMENTS ( MAX_LEN / 8 )
+
+
+struct Page {
+    u8 data[4096];
+};
+
+BPF_ARRAY(out_page_memory, u64, MAX_ELEMENTS);
+BPF_ARRAY(in_phys_addr, u64, 1);
+BPF_ARRAY(in_phys_len, u32, 1);
+BPF_ARRAY(in_pid, u32, 1);
+BPF_ARRAY(out_block, struct Page, 1);
+
+int read_memory(struct pt_regs *ctx) {
+    unsigned int zero = 0;
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    if (task == NULL) {
+        return 1;
+    }
+    u32 *pid_ptr = in_pid.lookup(&zero);
+    if (!pid_ptr) {
+        return 1;
+    }
+    if (task->pid != *pid_ptr) {
+        return 1;
+    }
+    unsigned long page_offset_base = 0;
+    if (bpf_probe_read(&page_offset_base, 8, (void *)$PAGE_OFFSET_BASE) < 0) {
+        return 1;
+    }
+    u32 *len_ptr = in_phys_len.lookup(&zero);
+    if (!len_ptr) {
+        return 1;
+    }
+    const u32 len = *len_ptr;
+    if (len > MAX_LEN)
+    {
+        return 1;
+    }
+    u64 *phys_addr_ptr = in_phys_addr.lookup(&zero);
+    if (!phys_addr_ptr) {
+        return 1;
+    }
+
+    struct Page *block_ptr = out_block.lookup(&zero);
+    if (!block_ptr) {
+        return 1;
+    }
+
+    u8 *phys_addr = 0x0;
+    phys_addr += *phys_addr_ptr;
+    phys_addr += page_offset_base;
+    if (bpf_probe_read(block_ptr, len, (const void *)phys_addr) != 0) {
+        bpf_trace_printk("Failed to read physical memory\n");
+        return 1;
+    }
+
+    bpf_trace_printk("Done\n");
+    return 0;
+}
+

--- a/pt_host/pt_host_read_cr3.bcc
+++ b/pt_host/pt_host_read_cr3.bcc
@@ -1,0 +1,33 @@
+
+#include <linux/sched.h>
+#include <linux/mm.h>
+
+BPF_ARRAY(out_cr3, u64, 1);
+
+int read_cr3(struct pt_regs *ctx) {
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    if (task == NULL) {
+        return 1;
+    }
+    if (task->pid != $PID) {
+        return 1;
+    }
+    struct mm_struct *mm = task->mm;
+    if (!mm) {
+        return 1;
+    }
+    unsigned long cr3 = (unsigned long)mm->pgd;
+    unsigned long page_offset_base =0;
+    if (bpf_probe_read(&page_offset_base, 8, (void *)$PAGE_OFFSET_BASE) < 0) {
+        return 1;
+    }
+    unsigned long cr3_phys_address = cr3 - page_offset_base;
+    u32 index = 0;
+    u64 *ptr = out_cr3.lookup(&index);
+    if (!ptr) {
+        return 1;
+    }
+    *ptr = cr3_phys_address;
+    bpf_trace_printk("Done\n");
+    return 0;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 readme = "README.md"
 packages = [
     { include = "pt" },
+    { include = "pt_gdb" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This branch covers the refactoring of gdb-pt-dump and the addition of a new feature to gdb-pt-dump: using the same functionality for host page tables.

The changes are the following:
- Add a "Machine" abstraction for reading physical memory and registers
- Add a QEMU-GDB based implementation of the Machine
- Clean-up code to use the Machine interface. This clean-ups the code from using the gdb python3 module.
- Add a "Host" implementation of the machine.
- Add "pt_host.py" interface. The arguments the ones used within gdb.

The "Host" implementations is done in the following way:
- CR0, CR4 and EFER are hardcoded to should be sane values for x86_64
- CR3 is read from task_struct via EBPF
- Physical memory is read via EBPF since /dev/mem is often restricted on most systems