### PR TITLE
Support Rust and Golang

### DIFF
--- a/pt_gdb/pt_gdb.py
+++ b/pt_gdb/pt_gdb.py
@@ -77,7 +77,12 @@ class QemuGdbMachine(Machine):
         return int(ret, 10)
 
     def read_register(self, register_name):
-        return int(gdb.parse_and_eval(register_name).cast(gdb.lookup_type("unsigned long")))
+        for type_name in ["unsigned long", "usize", "uintptr"]:
+            try:
+                return int(gdb.parse_and_eval(register_name).cast(gdb.lookup_type(type_name)))
+            except gdb.error:
+                continue
+        raise Exception(f"Could not read register {register_name}")
 
 class PageTableDumpGdbFrontend(gdb.Command):
     """


### PR DESCRIPTION
```
(gdb) py print(gdb.lookup_type("unsigned long").sizeof)
8
(gdb) set language go
(gdb) py print(gdb.lookup_type("unsigned long").sizeof)
Python Exception <class 'gdb.error'>: No type named unsigned long.
Error occurred in Python: No type named unsigned long.
(gdb) py print(gdb.lookup_type("uintptr").sizeof)
8
```