### PR TITLE
Update pt_gdb.py

### DIFF
--- a/pt_gdb/pt_gdb.py
+++ b/pt_gdb/pt_gdb.py
@@ -13,7 +13,6 @@ class QemuGdbMachine(Machine):
     def __init__(self):
         self.pid = QemuGdbMachine.get_qemu_pid()
         self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
-        self.mem_size = os.fstat(self.file).st_size
 
     def __del__(self):
         if self.file:


### PR DESCRIPTION
TL;DR remove redundant field from QemuMachine

```py
In [4]: f=os.open('/proc/self/mem', os.O_RDONLY)

In [5]: os.fstat(f).st_size
Out[5]: 0
```

Btw we will be re-using this code directly (as a copy) in Pwndbg since we want to use similar code to support LLDB. The PR adding it is here: https://github.com/pwndbg/pwndbg/pull/2634/files - @martinradev please let us know if we should extend the credit for you anyhow (or add verbose license comment or anything else).